### PR TITLE
ci(PRODSEC-343): consolidate CodeQL workflows into single unified scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # Daily at 01:00 UTC
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to scan (leave empty for default branch)'
+        required: false
+        default: ''
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    # branches: [master, main]
+
+# Cancel in-progress PR scans when new commits arrive; never cancel full scans.
+concurrency:
+  group: codeql-unified-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  scan:
+    # Skip draft PRs. Non-PR events are never drafts so this guard is a no-op
+    # for schedule/workflow_dispatch.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    uses: KeepTruckin/security-scanners/.github/workflows/codeql-scan.yml@master
+    with:
+      ref: ${{ inputs.ref || '' }}
+      # Full scans (schedule/dispatch) seed the overlay-base cache for PR scans.
+      # PR scans restore it read-only — they must NOT overwrite it.
+      save-cache: ${{ github.event_name != 'pull_request' }}
+    secrets: inherit
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+      packages: read


### PR DESCRIPTION
Replaces separate codeql-full-scan.yml and codeql-pr-scan.yml with a single unified codeql.yml workflow.